### PR TITLE
feat: add util function `include_surrounding_empty_lines()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,8 +154,9 @@ vim.keymap.set({"x", "o"}, "iI", function() require'treesitter_indent_object.tex
 
 #### Include Surrounding Whitespace
 
-There is an utility function that expands current selection to the surrounding empty lines.
+There is a helper function that expands current selection to the surrounding empty lines.
 Call it right after the textobject and it'll try to match the behavior of the builtin `ap` (a paragraph) keymap.
+See [#4](https://github.com/kiyoon/treesitter-indent-object.nvim/pull/4) for more details about its behavior.
 
 > [!NOTE]
 > This function is designed to work with line-wise selections (`'V'`) only!
@@ -165,7 +166,7 @@ Call it right after the textobject and it'll try to match the behavior of the bu
   "aI",
   function()
     require'treesitter_indent_object.textobj'.select_indent_outer(true, 'V')
-    require'treesitter_indent_object.utils'.include_surrounding_empty_lines()
+    require'treesitter_indent_object.refiner'.include_surrounding_empty_lines()
   end,
   mode = { "x", "o" },
 },

--- a/README.md
+++ b/README.md
@@ -9,7 +9,15 @@ Context-aware smart indent object to select block, powered by [treesitter](https
 This plugin is intended to be used with [indent-blankline.nvim](https://github.com/lukas-reineke/indent-blankline.nvim),
 so you see the scope before you select.
 
-NOTE: This plugin is only compatible with indent-blankline.nvim v2 because its definition of scope has been changed on v3. My personal preference is to keep using v2 as its scope aligns well with VSCode.
+> [!NOTE]
+> **This plugin is only compatible with `indent-blankline.nvim` v2** because its definition of scope has been changed on v3.
+> TL;DR - v2 scope is just "same indent level" while v3 uses an actual [semantic scope][scope] specific to each language.
+> My personal preference is to keep using v2 as its scope aligns well with VSCode.
+> The author does seem to plan on bringing back the old scope on v3 ([lukas-reineke/indent-blankline.nvim#649][issue]).
+
+[scope]: https://en.wikipedia.org/wiki/Scope_(computer_science)
+[issue]: https://github.com/lukas-reineke/indent-blankline.nvim/issues/649
+
 
 ## Install
 
@@ -140,4 +148,25 @@ vim.keymap.set({"x", "o"}, "ii", function() require'treesitter_indent_object.tex
 vim.keymap.set({"x", "o"}, "iI", function() require'treesitter_indent_object.textobj'.select_indent_inner(true, 'V') end)
 ```
 
-  </details>
+</details>
+
+## Tips and Tricks
+
+#### Include Surrounding Whitespace
+
+There is an utility function that expands current selection to the surrounding empty lines.
+Call it right after the textobject and it'll try to match the behavior of the builtin `ap` (a paragraph) keymap.
+
+> [!NOTE]
+> This function is designed to work with line-wise selections (`'V'`) only!
+
+```lua
+{
+  "aI",
+  function()
+    require'treesitter_indent_object.textobj'.select_indent_outer(true, 'V')
+    require'treesitter_indent_object.utils'.include_surrounding_empty_lines()
+  end,
+  mode = { "x", "o" },
+},
+```

--- a/lua/treesitter_indent_object/refiner.lua
+++ b/lua/treesitter_indent_object/refiner.lua
@@ -1,0 +1,31 @@
+local M = {}
+
+---Expand the linewise visual selection to the surrounding empty lines.
+M.include_surrounding_empty_lines = function()
+  local cur = vim.fn.line "."
+  local eob = vim.fn.line "$"
+
+  -- expand the selection to the empty lines below
+  local i = cur
+  while i < eob and vim.fn.getline(i + 1):match "^%s*$" ~= nil do
+    i = i + 1
+  end
+  vim.api.nvim_win_set_cursor(0, { i, 99999 })
+
+  -- if: there were no empty lines below (cursor did not move)
+  -- or *only* empty lines were below (cursor at the last line)
+  if i ~= cur and i ~= eob then
+    return
+  end
+
+  -- then: also expand the selection to the empty lines above
+  vim.cmd [[normal! o]]
+  local i = vim.fn.line "."
+  while i > 1 and vim.fn.getline(i - 1):match "^%s*$" ~= nil do
+    i = i - 1
+  end
+  vim.api.nvim_win_set_cursor(0, { i, 0 })
+  vim.cmd [[normal! o]]
+end
+
+return M

--- a/lua/treesitter_indent_object/utils.lua
+++ b/lua/treesitter_indent_object/utils.lua
@@ -82,7 +82,6 @@ M.find_indent = function(line_num)
   return indent + math.floor(spaces / shiftwidth)
 end
 
-
 -- Modified from indent_blankline.utils
 -- to return column as well
 M.get_current_context = function(type_patterns, use_treesitter_scope)
@@ -122,6 +121,34 @@ M.get_current_context = function(type_patterns, use_treesitter_scope)
   end
 
   return false
+end
+
+---Expand the linewise visual selection to the surrounding empty lines.
+M.include_surrounding_empty_lines = function()
+  local cur = vim.fn.line "."
+  local eob = vim.fn.line "$"
+
+  -- expand the selection to the empty lines below
+  local i = cur
+  while i < eob and vim.fn.getline(i + 1):match "^%s*$" ~= nil do
+    i = i + 1
+  end
+  vim.api.nvim_win_set_cursor(0, { i, 99999 })
+
+  -- if: there were no empty lines below (cursor did not move)
+  -- or *only* empty lines were below (cursor at the last line)
+  if i ~= cur and i ~= eob then
+    return
+  end
+
+  -- then: also expand the selection to the empty lines above
+  vim.cmd [[normal! o]]
+  local i = vim.fn.line "."
+  while i > 1 and vim.fn.getline(i - 1):match "^%s*$" ~= nil do
+    i = i - 1
+  end
+  vim.api.nvim_win_set_cursor(0, { i, 0 })
+  vim.cmd [[normal! o]]
 end
 
 return M

--- a/lua/treesitter_indent_object/utils.lua
+++ b/lua/treesitter_indent_object/utils.lua
@@ -123,32 +123,4 @@ M.get_current_context = function(type_patterns, use_treesitter_scope)
   return false
 end
 
----Expand the linewise visual selection to the surrounding empty lines.
-M.include_surrounding_empty_lines = function()
-  local cur = vim.fn.line "."
-  local eob = vim.fn.line "$"
-
-  -- expand the selection to the empty lines below
-  local i = cur
-  while i < eob and vim.fn.getline(i + 1):match "^%s*$" ~= nil do
-    i = i + 1
-  end
-  vim.api.nvim_win_set_cursor(0, { i, 99999 })
-
-  -- if: there were no empty lines below (cursor did not move)
-  -- or *only* empty lines were below (cursor at the last line)
-  if i ~= cur and i ~= eob then
-    return
-  end
-
-  -- then: also expand the selection to the empty lines above
-  vim.cmd [[normal! o]]
-  local i = vim.fn.line "."
-  while i > 1 and vim.fn.getline(i - 1):match "^%s*$" ~= nil do
-    i = i - 1
-  end
-  vim.api.nvim_win_set_cursor(0, { i, 0 })
-  vim.cmd [[normal! o]]
-end
-
 return M


### PR DESCRIPTION
Fixes #3.

After an embarrassing amount of off-by-one errors, I have created a more robust version of selection expansion.

```lua
---Expand the linewise visual selection to the surrounding empty lines.
M.include_surrounding_empty_lines = function()
  local cur = vim.fn.line "."
  local eob = vim.fn.line "$"

  -- expand the selection to the empty lines below
  local i = cur
  while i < eob and vim.fn.getline(i + 1):match "^%s*$" ~= nil do
    i = i + 1
  end
  vim.api.nvim_win_set_cursor(0, { i, 99999 })

  -- if: there were no empty lines below (cursor did not move)
  -- or *only* empty lines were below (cursor at the last line)
  if i ~= cur and i ~= eob then
    return
  end

  -- then: also expand the selection to the empty lines above
  vim.cmd [[normal! o]]
  local i = vim.fn.line "."
  while i > 1 and vim.fn.getline(i - 1):match "^%s*$" ~= nil do
    i = i - 1
  end
  vim.api.nvim_win_set_cursor(0, { i, 0 })
  vim.cmd [[normal! o]]
end
```
```lua
{
  "aI",
  function()
    require'treesitter_indent_object.textobj'.select_indent_outer(true, 'V')
    require'treesitter_indent_object.utils'.include_surrounding_empty_lines()
  end,
  mode = { "x", "o" },
}
```

It can expand the selection upwards as well as downwards when it makes sense to do so.
Here's an example of how `daI` would function after applying this.

#### Downwards

```diff
  def foo():
      pass

- def bar(): # <- cursor
-     pass
-
  def baz():
      pass
```

#### Upwards

```diff
  def foo():
      pass
-
- def bar(): # <- cursor
-     pass
```

#### Trailing empty lines

Expands both way if there are no further contents after the empty lines below.
This behavior can be observed from the builtin `ap` as well. I never knew this until now.

```diff
  def foo():
      pass
-
- def bar(): # <- cursor
-     pass
-
-
```

#### Expand upwards if cannot go down at all

I find this particularly useful. No other textobject can so precisely do what I want in this situation.

```diff
 fn example() {
     foo();
-
-    if bar() { // <- cursor
-        baz();
-    }
 }
```
